### PR TITLE
Fix dao tests and add possibility to test live data

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,8 @@ def nav_version = "2.5.3"
 
 dependencies {
     implementation 'androidx.test.ext:junit-ktx:1.1.4'
+    testImplementation 'androidx.arch.core:core-testing:2.1.0'
+    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
 
     // room dependency
     def room_version = "2.4.3"

--- a/app/src/androidTest/java/com/example/mytrainingpal/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.example.mytrainingpal
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/ExerciseDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/ExerciseDaoTest.kt
@@ -1,22 +1,30 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.ExerciseDao
 import com.example.mytrainingpal.model.entities.Exercise
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class ExerciseDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var exerciseDao: ExerciseDao
     private lateinit var db: TheMuscleBase
 
@@ -24,7 +32,8 @@ class ExerciseDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         exerciseDao = db.getExerciseDao()
     }
 
@@ -37,7 +46,7 @@ class ExerciseDaoTest {
     @Test
     @Throws(Exception::class)
     fun testInsert() {
-        var exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        var exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
         exercise = exercise.copy(exerciseId = exerciseId)
         val exerciseRet = exerciseDao.getExerciseById(exerciseId)
@@ -47,20 +56,20 @@ class ExerciseDaoTest {
     @Test
     @Throws(Exception::class)
     fun testDelete() {
-        var exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        var exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
         exercise = exercise.copy(exerciseId = exerciseId)
         val exerciseRet = exerciseDao.getExerciseById(exerciseId)
         assertThat(exerciseRet, equalTo(exercise))
         exerciseDao.deleteExercise(exercise)
-        val allExercises = exerciseDao.getAllExercises()
-        assertEquals(0, allExercises.value!!.size)
+        val allExercises = exerciseDao.getAllExercises().getOrAwaitValue()
+        assertEquals(0, allExercises.size)
     }
 
     @Test
     @Throws(Exception::class)
     fun testUpdate() {
-        var exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        var exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
         exercise = exercise.copy(exerciseId = exerciseId)
         var exerciseRet = exerciseDao.getExerciseById(exerciseId)

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/ExerciseMuscleMapDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/ExerciseMuscleMapDaoTest.kt
@@ -1,9 +1,9 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.ExerciseDao
 import com.example.mytrainingpal.model.daos.ExerciseMuscleMapDao
@@ -11,16 +11,24 @@ import com.example.mytrainingpal.model.daos.MuscleDao
 import com.example.mytrainingpal.model.entities.Exercise
 import com.example.mytrainingpal.model.entities.ExerciseMuscleMap
 import com.example.mytrainingpal.model.entities.Muscle
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class ExerciseMuscleMapDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var exerciseMuscleMapDao: ExerciseMuscleMapDao
     private lateinit var exerciseDao: ExerciseDao
     private lateinit var muscleDao: MuscleDao
@@ -30,7 +38,8 @@ class ExerciseMuscleMapDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         exerciseMuscleMapDao = db.getExerciseMuscleMapDao()
         exerciseDao = db.getExerciseDao()
         muscleDao = db.getMuscleDao()
@@ -47,7 +56,7 @@ class ExerciseMuscleMapDaoTest {
     fun testInsert() {
         val muscle = Muscle(null, "Biceps")
         val muscleId = muscleDao.insert(muscle)
-        val exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        val exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
         val exerciseMuscleMap = ExerciseMuscleMap(exerciseId, muscleId)
         val exerciseMuscleMapId = exerciseMuscleMapDao.insert(exerciseMuscleMap)
@@ -60,17 +69,17 @@ class ExerciseMuscleMapDaoTest {
     fun testDelete() {
         val muscle = Muscle(null, "Biceps")
         val muscleId = muscleDao.insert(muscle)
-        val exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        val exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
         val exerciseMuscleMap = ExerciseMuscleMap(exerciseId, muscleId)
         val exerciseMuscleMapId = exerciseMuscleMapDao.insert(exerciseMuscleMap)
         val exerciseMuscleMapRet = exerciseMuscleMapDao.getExerciseMuscleMapByExerciseId(exerciseId)
         assertThat(exerciseMuscleMapRet, equalTo(exerciseMuscleMap))
-        var allMaps = exerciseMuscleMapDao.getAllExerciseMuscleMaps()
-        assertEquals(1, allMaps.value!!.size)
+        var allMaps = exerciseMuscleMapDao.getAllExerciseMuscleMaps().getOrAwaitValue()
+        assertEquals(1, allMaps.size)
         exerciseMuscleMapDao.deleteExerciseMuscleMap(exerciseMuscleMap)
-        allMaps = exerciseMuscleMapDao.getAllExerciseMuscleMaps()
-        assertEquals(0, allMaps.value!!.size)
+        allMaps = exerciseMuscleMapDao.getAllExerciseMuscleMaps().getOrAwaitValue()
+        assertEquals(0, allMaps.size)
     }
 
     @Test
@@ -80,7 +89,7 @@ class ExerciseMuscleMapDaoTest {
         val muscle2 = Muscle(null, "Triceps")
         val muscleId = muscleDao.insert(muscle)
         val muscle2Id = muscleDao.insert(muscle2)
-        val exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        val exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
         val exerciseMuscleMap = ExerciseMuscleMap(exerciseId, muscleId)
         val exerciseMuscleMapId = exerciseMuscleMapDao.insert(exerciseMuscleMap)

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/MuscleDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/MuscleDaoTest.kt
@@ -1,22 +1,30 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.MuscleDao
 import com.example.mytrainingpal.model.entities.Muscle
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
 
 @RunWith(AndroidJUnit4::class)
 class MuscleDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var muscleDao: MuscleDao
     private lateinit var db: TheMuscleBase
 
@@ -24,7 +32,8 @@ class MuscleDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         muscleDao = db.getMuscleDao()
     }
 
@@ -52,8 +61,8 @@ class MuscleDaoTest {
         val muscleRet = muscleDao.getMuscleById(muscleId)
         assertThat(muscleRet, equalTo(muscle))
         muscleDao.deleteMuscle(muscle)
-        val allMuscles = muscleDao.getAllMuscles()
-        assertEquals(0, allMuscles.value!!.size)
+        val allMuscles = muscleDao.getAllMuscles().getOrAwaitValue()
+        assertEquals(0, allMuscles.size)
     }
 
     @Test

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/MusclePainEntryDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/MusclePainEntryDaoTest.kt
@@ -1,16 +1,19 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.MusclePainEntryDao
 import com.example.mytrainingpal.model.entities.MusclePainEntry
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -18,6 +21,11 @@ import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class MusclePainEntryDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var musclePainEntryDao: MusclePainEntryDao
     private lateinit var db: TheMuscleBase
 
@@ -25,7 +33,8 @@ class MusclePainEntryDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         musclePainEntryDao = db.getMusclePainEntryDao()
     }
 
@@ -38,7 +47,8 @@ class MusclePainEntryDaoTest {
     @Test
     @Throws(Exception::class)
     fun testInsert() {
-        var musclePainEntry = MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
+        var musclePainEntry =
+            MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
         val musclePainEntryId = musclePainEntryDao.insert(musclePainEntry)
         musclePainEntry = musclePainEntry.copy(musclePainEntryId = musclePainEntryId)
         val musclePainEntryRet = musclePainEntryDao.getMusclePainEntryById(musclePainEntryId)
@@ -48,20 +58,22 @@ class MusclePainEntryDaoTest {
     @Test
     @Throws(Exception::class)
     fun testDelete() {
-        var musclePainEntry = MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
+        var musclePainEntry =
+            MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
         val musclePainEntryId = musclePainEntryDao.insert(musclePainEntry)
         musclePainEntry = musclePainEntry.copy(musclePainEntryId = musclePainEntryId)
         val musclePainEntryRet = musclePainEntryDao.getMusclePainEntryById(musclePainEntryId)
         assertThat(musclePainEntryRet, equalTo(musclePainEntry))
         musclePainEntryDao.deleteMusclePainEntry(musclePainEntry)
-        val allMusclePainEntries = musclePainEntryDao.getAllMusclePainEntries()
-        assertEquals(0, allMusclePainEntries.value!!.size)
+        val allMusclePainEntries = musclePainEntryDao.getAllMusclePainEntries().getOrAwaitValue()
+        assertEquals(0, allMusclePainEntries.size)
     }
 
     @Test
     @Throws(Exception::class)
     fun testUpdate() {
-        var musclePainEntry = MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
+        var musclePainEntry =
+            MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
         val musclePainEntryId = musclePainEntryDao.insert(musclePainEntry)
         musclePainEntry = musclePainEntry.copy(musclePainEntryId = musclePainEntryId)
         var musclePainEntryRet = musclePainEntryDao.getMusclePainEntryById(musclePainEntryId)

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/MusclePainEntryMapDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/MusclePainEntryMapDaoTest.kt
@@ -1,19 +1,22 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.MuscleDao
 import com.example.mytrainingpal.model.daos.MusclePainEntryDao
 import com.example.mytrainingpal.model.daos.MusclePainEntryMapDao
 import com.example.mytrainingpal.model.entities.Muscle
 import com.example.mytrainingpal.model.entities.MusclePainEntry
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -21,6 +24,11 @@ import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class MusclePainEntryMapDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var musclePainEntryMapDao: MusclePainEntryMapDao
     private lateinit var musclePainEntryDao: MusclePainEntryDao
     private lateinit var muscleDao: MuscleDao
@@ -30,7 +38,8 @@ class MusclePainEntryMapDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         musclePainEntryMapDao = db.getMusclePainEntryMapDao()
         musclePainEntryDao = db.getMusclePainEntryDao()
         muscleDao = db.getMuscleDao()
@@ -47,11 +56,17 @@ class MusclePainEntryMapDaoTest {
     fun testInsert() {
         val muscle = Muscle(null, "Biceps")
         val muscleId = muscleDao.insert(muscle)
-        var musclePainEntry = MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
+        var musclePainEntry =
+            MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
         val musclePainEntryId = musclePainEntryDao.insert(musclePainEntry)
-        val musclePainEntryMap = MusclePainEntryMap(musclePainEntryId, muscleId, MusclePainEntryMapConstants.MODERATE_PAIN)
+        val musclePainEntryMap = MusclePainEntryMap(
+            musclePainEntryId,
+            muscleId,
+            MusclePainEntryMapConstants.MODERATE_PAIN
+        )
         val musclePainEntryMapId = musclePainEntryMapDao.insert(musclePainEntryMap)
-        val musclePainEntryMapRet = musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryId)
+        val musclePainEntryMapRet =
+            musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryId)
         assertThat(musclePainEntryMapRet, equalTo(musclePainEntryMap))
     }
 
@@ -60,17 +75,23 @@ class MusclePainEntryMapDaoTest {
     fun testDelete() {
         val muscle = Muscle(null, "Biceps")
         val muscleId = muscleDao.insert(muscle)
-        var musclePainEntry = MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
+        var musclePainEntry =
+            MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
         val musclePainEntryId = musclePainEntryDao.insert(musclePainEntry)
-        val musclePainEntryMap = MusclePainEntryMap(musclePainEntryId, muscleId, MusclePainEntryMapConstants.MODERATE_PAIN)
+        val musclePainEntryMap = MusclePainEntryMap(
+            musclePainEntryId,
+            muscleId,
+            MusclePainEntryMapConstants.MODERATE_PAIN
+        )
         val musclePainEntryMapId = musclePainEntryMapDao.insert(musclePainEntryMap)
-        val musclePainEntryMapRet = musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryMapId)
+        val musclePainEntryMapRet =
+            musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryMapId)
         assertThat(musclePainEntryMapRet, equalTo(musclePainEntryMap))
-        var allMaps = musclePainEntryMapDao.getAllSoreMuscleEntryMaps()
-        assertEquals(1, allMaps.value!!.size)
+        var allMaps = musclePainEntryMapDao.getAllSoreMuscleEntryMaps().getOrAwaitValue()
+        assertEquals(1, allMaps.size)
         musclePainEntryMapDao.deleteMusclePainEntryMap(musclePainEntryMap)
-        allMaps = musclePainEntryMapDao.getAllSoreMuscleEntryMaps()
-        assertEquals(0, allMaps.value!!.size)
+        allMaps = musclePainEntryMapDao.getAllSoreMuscleEntryMaps().getOrAwaitValue()
+        assertEquals(0, allMaps.size)
     }
 
     @Test
@@ -78,16 +99,23 @@ class MusclePainEntryMapDaoTest {
     fun testUpdate() {
         val muscle = Muscle(null, "Biceps")
         val muscleId = muscleDao.insert(muscle)
-        val musclePainEntry = MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
+        val musclePainEntry =
+            MusclePainEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time)
         val musclePainEntryId = musclePainEntryDao.insert(musclePainEntry)
-        val musclePainEntryMap = MusclePainEntryMap(musclePainEntryId, muscleId, MusclePainEntryMapConstants.MODERATE_PAIN)
+        val musclePainEntryMap = MusclePainEntryMap(
+            musclePainEntryId,
+            muscleId,
+            MusclePainEntryMapConstants.MODERATE_PAIN
+        )
         val musclePainEntryMapId = musclePainEntryMapDao.insert(musclePainEntryMap)
-        var musclePainEntryMapRet = musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryId)
+        var musclePainEntryMapRet =
+            musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryId)
         assertThat(musclePainEntryMapRet, equalTo(musclePainEntryMap))
         val updatedSoreness = MusclePainEntryMapConstants.SEVERE_PAIN
         musclePainEntryMap.painIntensity = updatedSoreness
         musclePainEntryMapDao.updateMusclePainEntryMap(musclePainEntryMap)
-        musclePainEntryMapRet = musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryMapId)
+        musclePainEntryMapRet =
+            musclePainEntryMapDao.getMusclePainEntryMapByMusclePainEntryIdMap(musclePainEntryMapId)
         assertThat(musclePainEntryMapRet, equalTo(musclePainEntryMap))
     }
 

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/WorkoutEntryDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/WorkoutEntryDaoTest.kt
@@ -1,16 +1,19 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.WorkoutEntryDao
 import com.example.mytrainingpal.model.entities.WorkoutEntry
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -18,6 +21,12 @@ import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class WorkoutEntryDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+
     private lateinit var workoutEntryDao: WorkoutEntryDao
     private lateinit var db: TheMuscleBase
 
@@ -25,7 +34,8 @@ class WorkoutEntryDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         workoutEntryDao = db.getWorkoutEntryDao()
     }
 
@@ -38,7 +48,26 @@ class WorkoutEntryDaoTest {
     @Test
     @Throws(Exception::class)
     fun testInsert() {
-        var workoutEntry = WorkoutEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,"12:12:00","13:30:22","",null)
+        var workoutEntry = WorkoutEntry(
+            null,
+            GregorianCalendar(2022, Calendar.DECEMBER, 1).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                12,
+                30
+            ).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                14,
+                30
+            ).time,
+            "",
+            null
+        )
         val workoutEntryId = workoutEntryDao.insert(workoutEntry)
         workoutEntry = workoutEntry.copy(workoutId = workoutEntryId)
         val workoutEntryRet = workoutEntryDao.getWorkoutEntryById(workoutEntryId)
@@ -48,20 +77,53 @@ class WorkoutEntryDaoTest {
     @Test
     @Throws(Exception::class)
     fun testDelete() {
-        var workoutEntry = WorkoutEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,"12:12:00","13:30:22","",null)
+        var workoutEntry = WorkoutEntry(
+            null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                12,
+                30
+            ).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                14,
+                30
+            ).time, "", null
+        )
         val workoutEntryId = workoutEntryDao.insert(workoutEntry)
         workoutEntry = workoutEntry.copy(workoutId = workoutEntryId)
         val workoutEntryRet = workoutEntryDao.getWorkoutEntryById(workoutEntryId)
         assertThat(workoutEntryRet, equalTo(workoutEntry))
         workoutEntryDao.deleteWorkoutEntry(workoutEntry)
         val allWorkoutEntries = workoutEntryDao.getAllWorkoutEntries()
-        assertEquals(0, allWorkoutEntries.value!!.size)
+        val value = allWorkoutEntries.getOrAwaitValue()
+        assertEquals(0, value.size)
     }
 
     @Test
     @Throws(Exception::class)
     fun testUpdate() {
-        var workoutEntry = WorkoutEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,"12:12:00","13:30:22","",null)
+        var workoutEntry = WorkoutEntry(
+            null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                12,
+                30
+            ).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                14,
+                30
+            ).time, "", null
+        )
         val workoutEntryId = workoutEntryDao.insert(workoutEntry)
         workoutEntry = workoutEntry.copy(workoutId = workoutEntryId)
         var workoutEntryRet = workoutEntryDao.getWorkoutEntryById(workoutEntryId)

--- a/app/src/androidTest/java/com/example/mytrainingpal/model/WorkoutEntryExerciseMapDaoTest.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/model/WorkoutEntryExerciseMapDaoTest.kt
@@ -1,9 +1,9 @@
 package com.example.mytrainingpal.model
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.mytrainingpal.model.daos.ExerciseDao
 import com.example.mytrainingpal.model.daos.WorkoutEntryDao
@@ -11,10 +11,13 @@ import com.example.mytrainingpal.model.daos.WorkoutEntryExerciseMapDao
 import com.example.mytrainingpal.model.entities.Exercise
 import com.example.mytrainingpal.model.entities.WorkoutEntry
 import com.example.mytrainingpal.model.entities.WorkoutEntryExerciseMap
+import com.example.mytrainingpal.utils.getOrAwaitValue
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
@@ -22,6 +25,11 @@ import java.util.*
 
 @RunWith(AndroidJUnit4::class)
 class WorkoutEntryExerciseMapDaoTest {
+    // Run tasks synchronously by Jose Alcérreca. See TestingUtils.kt.
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
     private lateinit var workoutEntryDao: WorkoutEntryDao
     private lateinit var exerciseDao: ExerciseDao
     private lateinit var workoutEntryExerciseMapDao: WorkoutEntryExerciseMapDao
@@ -31,7 +39,8 @@ class WorkoutEntryExerciseMapDaoTest {
     fun createDb() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
-            context, TheMuscleBase::class.java).build()
+            context, TheMuscleBase::class.java
+        ).build()
         workoutEntryDao = db.getWorkoutEntryDao()
         exerciseDao = db.getExerciseDao()
         workoutEntryExerciseMapDao = db.getWorkoutEntryExerciseMapDao()
@@ -46,49 +55,113 @@ class WorkoutEntryExerciseMapDaoTest {
     @Test
     @Throws(Exception::class)
     fun testInsert() {
-        val workoutEntry = WorkoutEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,"12:12:00","13:30:22","",null)
+        val workoutEntry = WorkoutEntry(
+            null,
+            GregorianCalendar(2022, Calendar.DECEMBER, 1).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                12,
+                30
+            ).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                14,
+                30
+            ).time,
+            "",
+            null
+        )
         val workoutEntryId = workoutEntryDao.insert(workoutEntry)
-        val exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        val exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
-        val workoutEntryExerciseMap = WorkoutEntryExerciseMap(workoutEntryId, exerciseId, 4, "10,10,10,10", 20)
+        val workoutEntryExerciseMap =
+            WorkoutEntryExerciseMap(workoutEntryId, exerciseId, 4, "10,10,10,10", 20)
         val workoutEntryExerciseMapId = workoutEntryExerciseMapDao.insert(workoutEntryExerciseMap)
-        val workoutEntryExerciseMapRet = workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
+        val workoutEntryExerciseMapRet =
+            workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
         assertThat(workoutEntryExerciseMapRet, equalTo(workoutEntryExerciseMap))
     }
 
     @Test
     @Throws(Exception::class)
     fun testDelete() {
-        val workoutEntry = WorkoutEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,"12:12:00","13:30:22","",null)
+        val workoutEntry = WorkoutEntry(
+            null,
+            GregorianCalendar(2022, Calendar.DECEMBER, 1).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                12,
+                30
+            ).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                14,
+                30
+            ).time,
+            "",
+            null
+        )
         val workoutEntryId = workoutEntryDao.insert(workoutEntry)
-        val exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        val exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
-        val workoutEntryExerciseMap = WorkoutEntryExerciseMap(workoutEntryId, exerciseId, 4, "10,10,10,10", 20)
+        val workoutEntryExerciseMap =
+            WorkoutEntryExerciseMap(workoutEntryId, exerciseId, 4, "10,10,10,10", 20)
         val workoutEntryExerciseMapId = workoutEntryExerciseMapDao.insert(workoutEntryExerciseMap)
-        val workoutEntryExerciseMapRet = workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
+        val workoutEntryExerciseMapRet =
+            workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
         assertThat(workoutEntryExerciseMapRet, equalTo(workoutEntryExerciseMap))
-        var allMaps = workoutEntryExerciseMapDao.getAllWorkoutEntryExerciseMaps()
-        assertEquals(1, allMaps.value!!.size)
+        var allMaps = workoutEntryExerciseMapDao.getAllWorkoutEntryExerciseMaps().getOrAwaitValue()
+        assertEquals(1, allMaps.size)
         workoutEntryExerciseMapDao.deleteWorkoutEntryExerciseMap(workoutEntryExerciseMap)
-        allMaps = workoutEntryExerciseMapDao.getAllWorkoutEntryExerciseMaps()
-        assertEquals(0, allMaps.value!!.size)
+        allMaps = workoutEntryExerciseMapDao.getAllWorkoutEntryExerciseMaps().getOrAwaitValue()
+        assertEquals(0, allMaps.size)
     }
 
     @Test
     @Throws(Exception::class)
     fun testUpdate() {
-        val workoutEntry = WorkoutEntry(null, GregorianCalendar(2022, Calendar.DECEMBER, 1).time,"12:12:00","13:30:22","",null)
+        val workoutEntry = WorkoutEntry(
+            null,
+            GregorianCalendar(2022, Calendar.DECEMBER, 1).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                12,
+                30
+            ).time,
+            GregorianCalendar(
+                2022,
+                Calendar.DECEMBER,
+                1,
+                14,
+                30
+            ).time,
+            "",
+            null
+        )
         val workoutEntryId = workoutEntryDao.insert(workoutEntry)
-        val exercise = Exercise(null, "Biceps Curls", "exercise_1",)
+        val exercise = Exercise(null, "Biceps Curls", "exercise_1")
         val exerciseId = exerciseDao.insert(exercise)
-        var workoutEntryExerciseMap = WorkoutEntryExerciseMap(workoutEntryId, exerciseId, 4, "10,10,10,10", 20)
+        var workoutEntryExerciseMap =
+            WorkoutEntryExerciseMap(workoutEntryId, exerciseId, 4, "10,10,10,10", 20)
         val workoutEntryExerciseMapId = workoutEntryExerciseMapDao.insert(workoutEntryExerciseMap)
-        var workoutEntryExerciseMapRet = workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
+        var workoutEntryExerciseMapRet =
+            workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
         assertThat(workoutEntryExerciseMapRet, equalTo(workoutEntryExerciseMap))
         val updatedReps = "10,10,8,8"
         workoutEntryExerciseMap = workoutEntryExerciseMap.copy(reps = updatedReps)
         workoutEntryExerciseMapDao.updateWorkoutEntryExerciseMap(workoutEntryExerciseMap)
-        workoutEntryExerciseMapRet = workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
+        workoutEntryExerciseMapRet =
+            workoutEntryExerciseMapDao.getWorkoutEntryExerciseMapByWorkoutId(workoutEntryId)
         assertThat(workoutEntryExerciseMapRet, equalTo(workoutEntryExerciseMap))
     }
 }

--- a/app/src/androidTest/java/com/example/mytrainingpal/utils/TestingUtils.kt
+++ b/app/src/androidTest/java/com/example/mytrainingpal/utils/TestingUtils.kt
@@ -1,0 +1,38 @@
+package com.example.mytrainingpal.utils
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+
+// Observing LiveData for testing by Jose Alcérreca
+// https://medium.com/androiddevelopers/unit-testing-livedata-and-other-common-observability-problems-bb477262eb04
+// and https://github.com/android/architecture-components-samples/blob/master/LiveDataSample/app/src/test/java/com/android/example/livedatabuilder/LiveDataViewModelTest.kt
+/* Copyright 2019 Google LLC.
+   SPDX-License-Identifier: Apache-2.0 */
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
+        }
+    }
+
+    this.observeForever(observer)
+
+    // Don't wait indefinitely if the LiveData is not set.
+    if (!latch.await(time, timeUnit)) {
+        throw TimeoutException("LiveData value was never set.")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/main/java/com/example/mytrainingpal/model/entities/Exercise.kt
+++ b/app/src/main/java/com/example/mytrainingpal/model/entities/Exercise.kt
@@ -10,5 +10,4 @@ data class Exercise(
     val exerciseId: Long? = null,
     val name: String,
     var pathToGif: String,
-) {
-}
+)

--- a/app/src/main/java/com/example/mytrainingpal/model/entities/MusclePainEntry.kt
+++ b/app/src/main/java/com/example/mytrainingpal/model/entities/MusclePainEntry.kt
@@ -11,5 +11,4 @@ data class MusclePainEntry(
     val musclePainEntryId: Long? = null,
     @TypeConverters(DateConverter::class)
     var date: Date
-) {
-}
+)

--- a/app/src/main/java/com/example/mytrainingpal/model/entities/WorkoutEntry.kt
+++ b/app/src/main/java/com/example/mytrainingpal/model/entities/WorkoutEntry.kt
@@ -17,5 +17,4 @@ data class WorkoutEntry(
     val endTime: Date,
     val comment: String,
     val picturePath: String? = null
-) {
-}
+)


### PR DESCRIPTION
The dao tests were broken for quite some time. The moment they started to return LiveData object, the tests did not work anymore. I added some utils that make it possible to wait for the LiveData object to load the data with the help of this post: 
https://medium.com/androiddevelopers/unit-testing-livedata-and-other-common-observability-problems-bb477262eb04


In short: 
- Add a function to the livedata objects that makes it possible to wait for them.
- Make every test run "synchronously" having nothing running on some "background coroutines" by adding the `InstantTaskExecutorRule` to it.